### PR TITLE
Add cwd option for child process; Update Readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ export default {
       args: ['scriptArgument1', 'scriptArgument2'], // pass args to script
       signal: false | true | 'SIGUSR2', // signal to send for HMR (defaults to `false`, uses 'SIGUSR2' if `true`)
       keyboard: true | false, // Allow typing 'rs' to restart the server. default: only if NODE_ENV is 'development'
+      cwd: undefined | string, // set a current working directory for the child process default: current cwd
     }),
   ],
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export type RunScriptWebpackPluginOptions = {
   args: string[];
   signal: boolean | ProcessKillSignal;
   keyboard: boolean;
+  cwd?: string;
   restartable?: boolean;
 };
 
@@ -150,12 +151,13 @@ class RunScriptWebpackPlugin implements WebpackPluginInstance {
   };
 
   private _startServer(cb: (arg0: ChildProcess) => void): void {
-    const { args, nodeArgs } = this.options;
+    const { args, nodeArgs, cwd } = this.options;
     if (!this._entrypoint) throw new Error('run-script-webpack-plugin requires an entrypoint.');
 
     const child = fork(this._entrypoint, args, {
       execArgv: nodeArgs,
       stdio: 'inherit',
+      cwd,
     });
     setTimeout(() => cb(child), 0);
   }


### PR DESCRIPTION
**Background**

At first thanks for the great webpack plugin, it comes in quite handy! :wink: I'm right now utilizing it in a monorepo project, where we would like to bundle on a global level, but start the applications locally. Therefore we would need to set the cwd of the child task.

**Tasks**

 - [x] Add cwd option for child process
 - [x] Update readme to reflect changes