### PR TITLE
Pass child nodeArgs explicitely

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class RunScriptWebpackPlugin implements WebpackPluginInstance {
       keyboard: process.env.NODE_ENV === 'development',
       ...options,
       args: [...(options.args || [])],
-      nodeArgs: [...process.execArgv, ...(options.nodeArgs || [])],
+      nodeArgs: [...(options.nodeArgs || process.execArgv)],
     };
 
     if (this.options.restartable) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ class RunScriptWebpackPlugin implements WebpackPluginInstance {
       keyboard: process.env.NODE_ENV === 'development',
       ...options,
       args: [...(options.args || [])],
-      nodeArgs: [...(options.nodeArgs || process.execArgv)],
+      nodeArgs: options.nodeArgs || process.execArgv,
     };
 
     if (this.options.restartable) {


### PR DESCRIPTION
**Problem**

In my case child process `execArgv` differ from `process.execArgv`. So it would be nice to pass them explicitly.


**Proposal**

- Instead of extending `process.execArgv` use it as fallback
- extending `process.execArgv` is up to the caller e.g.

 ```ts
new RunScriptWebpackPlugin({ nodeArgs: [ ...process.execArgv, ...nodeArgs ] })
```