### PR TITLE
Feature request: kill script after webpack-watch stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ export default {
       signal: false | true | 'SIGUSR2', // signal to send for HMR (defaults to `false`, uses 'SIGUSR2' if `true`)
       keyboard: true | false, // Allow typing 'rs' to restart the server. default: only if NODE_ENV is 'development'
       cwd: undefined | string, // set a current working directory for the child process default: current cwd
+      cleanup: false | true, // false by default, makes sure the script is killed when webpack is exiting
     }),
   ],
 }
@@ -45,7 +46,7 @@ If you don't pass a name, the plugin will tell you the available names.
 
 You can use `nodeArgs` and `args` to pass arguments to node and your script, respectively. For example, you can use this to use the node debugger.
 
-To use Hot Module Reloading with your server code, set Webpack to "hot" mode and include the `webpack/hot/poll` or `webpack/hot/signal` modules. Make sure they are part of your server bundle, e.g. if you are using `node-externals` put them in your whitelist. The latter module requires the `signal` option.
+To use Hot Module Reloading with your server code, set Webpack to include the `webpack/hot/poll` or `webpack/hot/signal` modules. Make sure they are part of your server bundle, e.g. if you are using `node-externals` put them in your whitelist. The latter module requires the `signal` option.
 
 ### License
 


### PR DESCRIPTION
I'm using the plugin to start a server after the watch updates the bundle. Except the fork is not managed after you Ctrl-C webpack. This adds a `cleanup` options to clear any running scripts after webpack closes.

Also noticed that when a script is already forked it is only killed on an emit from webpack. Not sure why it was so but is was not working for me. Now it reboots the script like I expect it would.

