### PR TITLE
fix: avoid null check on signal as it is optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ export class RunScriptWebpackPlugin implements WebpackPluginInstance {
 
   private _stopServer() {
     const signal = getSignal(this.options.signal);
-    if (signal && (this.worker?.pid)) {
+    if (this.worker?.pid) {
       process.kill(this.worker.pid, signal);
     }
   };


### PR DESCRIPTION
Our processes started hanging suddenly throwing port in use error on code changes (graceful restart)
I found out recent update introduced a bug which checks optional parameter and prevents killing the process.

Ref: https://github.com/nocodb/nocodb/pull/10507

This was hard to debug, so I would recommend publishing this when possible.